### PR TITLE
Fix block polling

### DIFF
--- a/lib/core/block-polling.js
+++ b/lib/core/block-polling.js
@@ -57,9 +57,10 @@ class BlockPolling {
           const blockEvents = events.filter(e => e.blockNumber === i);
 
           this._notify(i, status, blockEvents);
+          if (blockEvents) {
+            this._latestQueriedBlock = Math.max(this._latestQueriedBlock, i);
+          }
         }
-
-        this._latestQueriedBlock = toBlock;
       }
 
       const delay = toBlock === latestBlock ? this._pollInterval : 0;


### PR DESCRIPTION
Fix `block-polling` to only update `_lastQueriedBlock` if that block was actually returned in the query - this prevents the polling from always staying ahead of what `getPastLogs` is actually giving back to us